### PR TITLE
Eliminate duplicate linting step in pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -78,11 +78,6 @@ stages:
         codeCoverageTool: 'Cobertura'
         summaryFileLocation: '$(Build.SourcesDirectory)/coverage.xml'
       displayName: 'Publish code coverage results'
-    - script: |
-        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.22.2
-        $HOME/go/bin/golangci-lint run
-      displayName: 'Lint code'
-      continueOnError: true
   - job: Build
     displayName: Build Dockerfile
     pool:


### PR DESCRIPTION
When attempting to reorder tasks it was accidentally duplicated instead
of being moved.