### PR TITLE
Persistence redesign

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,6 @@ FROM scratch AS final
 
 COPY --from=build /main /main
 
-# run as unpriviliged user. 0xfe is used for `nobody` on debian, but this
-# container doesn't have /etc/passwd, so anything other than 0 would work
-USER 65534:65534
+WORKDIR /tmp/repricer
 EXPOSE 8080
 ENTRYPOINT ["/main"]

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -125,6 +125,7 @@ stages:
               manifests: |
                 $(Pipeline.Workspace)/manifests/deployment.yml
                 $(Pipeline.Workspace)/manifests/service.yml
+                $(Pipeline.Workspace)/manifests/storage.yml
               imagePullSecrets: |
                 $(imagePullSecret)
               containers: |
@@ -166,6 +167,7 @@ stages:
               manifests: |
                 $(Pipeline.Workspace)/manifests/deployment.yml
                 $(Pipeline.Workspace)/manifests/service.yml
+                $(Pipeline.Workspace)/manifests/storage.yml
               imagePullSecrets: |
                 $(imagePullSecret)
               containers: |

--- a/main.go
+++ b/main.go
@@ -9,7 +9,7 @@ import (
 )
 
 func main() {
-	apiMux := handlers.API(storage.New())
+	apiMux := handlers.API(storage.New("."))
 
 	go func() {
 		// just a fake set of healthchecks since the app currently entirely statless

--- a/manifests/deployment.yml
+++ b/manifests/deployment.yml
@@ -4,11 +4,17 @@ metadata:
   name: repricer 
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:
         app: repricer 
     spec:
+      securityContext:
+        runAsUser: 65534
+        runAsGroup: 65534
+        fsGroup: 65534
       containers:
         - name: repricer 
           image: repricer.azurecr.io/repricer
@@ -23,3 +29,10 @@ spec:
             httpGet:
               path: /healthz/ready
               port: 9102
+          volumeMounts:
+            - mountPath: "/tmp/repricer"
+              name: data
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: repricer-data

--- a/manifests/storage.yml
+++ b/manifests/storage.yml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: repricer-data
+spec:
+  accessModes:
+  - ReadWriteOnce
+  storageClassName: managed-premium
+  resources:
+    requests:
+      storage: 1Gi

--- a/storage/batch_writer.go
+++ b/storage/batch_writer.go
@@ -1,0 +1,203 @@
+package storage
+
+import (
+	"encoding/json"
+	"math"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+const (
+	FlushInterval       = time.Second
+	MaxRecordsPerFile   = 10
+	ResultsSubdirectory = "results"
+	ProductSubdirectory = "results_by_product"
+)
+
+// batchWriter is a recordwriter that writes records in batches.
+// it is not safe for concurrent use
+// init with a file seq #s
+// implement recordWriter interface
+type batchWriter struct {
+	fs writeFS
+
+	fileSeq  int64
+	entrySeq int64
+
+	*batch
+}
+
+func (w *batchWriter) writeRecord(r *record) (err error) {
+	err = w.startBatchIfNeeded(r.entry.Time)
+	if err != nil {
+		return
+	}
+
+	// ensure batch is flushed if it's full
+	if w.batch.nRecords+1 == MaxRecordsPerFile {
+		defer w.closeBatch()
+	}
+
+	defer func() {
+		if err == nil {
+			w.entrySeq++
+		}
+	}()
+
+	return w.batch.writeRecord(r)
+}
+
+func (w *batchWriter) startBatchIfNeeded(now time.Time) (err error) {
+	if w.batch != nil {
+		if now.Sub(w.batch.start) < FlushInterval {
+			// batch is set, and OK to use
+			return nil
+		} else {
+			// next event is too late for batch
+			w.closeBatch()
+		}
+	}
+
+	b := &batch{
+		fs: w.fs,
+		filename: filename{
+			fileSeq:  w.fileSeq + 1,
+			entrySeq: w.entrySeq + 1,
+			start:    now,
+		},
+
+		end: now,
+	}
+
+	// FIXME refactor filepath logic into some abstraction
+	b.file, err = w.fs.New(filepath.Join(ResultsSubdirectory, b.filename.String()))
+	if err != nil {
+		return err
+	}
+
+	w.fileSeq++
+
+	err = b.initialize()
+	if err != nil {
+		return err
+	}
+
+	w.batch = b
+
+	return nil
+}
+
+func (w *batchWriter) closeBatch() {
+	batch := w.batch
+	w.batch = nil
+	batch.flush()
+}
+
+type batch struct {
+	fs writeFS
+
+	filename
+	end time.Time
+
+	productIds map[string]int
+
+	file   appendFile
+	synced chan struct{} // closes when synced
+
+	flushOnce sync.Once
+
+	sync.Mutex // FIXME needed because of outstanding data race
+}
+
+func (b *batch) initialize() error {
+	b.productIds = make(map[string]int, 10)
+	b.synced = make(chan struct{})
+
+	// ensure buffer is always flushed after it can no longer be filled
+	time.AfterFunc(FlushInterval, func() {
+		b.flush()
+	})
+
+	// FIXME redo with ndjson for robustness
+	_, err := b.file.Write([]byte("[\n\t")) // start a JSON array as per spec
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (b *batch) writeRecord(r *record) (err error) {
+	if r.entry.Time.Before(b.end) {
+		panic("time went backwards")
+	}
+
+	// FIXME due to data races on internal fields, should not be necessary in principle
+	b.Lock()
+	defer b.Unlock()
+
+	// FIXME ndjson to remove this hack while retaining durability of early writes
+	if b.nRecords > 0 && err == nil {
+		_, err = b.file.Write([]byte(",\n\t"))
+		if err != nil {
+			return
+		}
+	}
+
+	by, err := json.MarshalIndent(r, "\t", "\t")
+	if err != nil {
+		return
+	}
+
+	_, err = b.file.Write(by)
+	if err != nil {
+		return
+	}
+
+	old := b.filename
+	b.nRecords++
+	b.end = r.entry.Time
+	if b.productIds[r.ProductId] == 0 {
+		b.nProductIds++
+	}
+	b.productIds[r.ProductId]++
+
+	// keep update nRecords and nProducts fields up to date in the filename
+	err = b.fs.Rename(
+		// TODO abstract ResultsSubdirectory logic
+		filepath.Join(ResultsSubdirectory, old.String()),
+		filepath.Join(ResultsSubdirectory, b.filename.String()),
+	)
+
+	// TODO how to track entrySeq per product?
+	// could keep track and independently load from snapshot
+	return
+}
+
+func (b *batch) flush() {
+	b.flushOnce.Do(func() {
+		go func() {
+			b.Lock() // FIXME still needed due to data race on f.filename, in principle should not be necessary
+			defer b.Unlock()
+
+			_, _ = b.file.Write([]byte("\n]\n")) // TODO error
+			_ = b.file.Sync()                    // TODO error
+			_ = b.file.Close()                   // TODO error
+
+			// TODO abstract filepath logic
+			finalName := filepath.Join(ResultsSubdirectory, b.filename.String())
+
+			// link to product index directories
+			for productId, count := range b.productIds {
+				productFilename := b.filename
+				productFilename.nRecords = int64(count)
+				productFilename.entrySeq = math.MaxInt64 // FIXME entrySeq needs to be seq *per product ID*
+
+				_ = b.fs.Link(finalName, filepath.Join(ProductSubdirectory, ProductIdHash(productId), productFilename.String())) // TODO error
+			}
+
+			close(b.synced)
+		}()
+	})
+}

--- a/storage/batch_writer.go
+++ b/storage/batch_writer.go
@@ -8,11 +8,12 @@ import (
 )
 
 const (
-	FlushInterval       = time.Second
 	MaxRecordsPerFile   = 10
 	ResultsSubdirectory = "results"
 	ProductSubdirectory = "results_by_product"
 )
+
+var FlushInterval = time.Second // FIXME make into a parameter. turned var from const to make tests more responsive
 
 // batchWriter is a recordwriter that writes records in batches.
 // it is not safe for concurrent use

--- a/storage/batch_writer_test.go
+++ b/storage/batch_writer_test.go
@@ -1,0 +1,226 @@
+package storage
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestBatchWriterContents(t *testing.T) {
+	fs := newMemFS()
+	w := batchWriter{fs: fs}
+
+	t0 := time.Now().UTC().Truncate(0)
+	r0 := &record{ProductId: "foo", entry: entry{Price: json.Number("3.50"), Time: t0}}
+
+	err := w.writeRecord(r0)
+	if err != nil {
+		t.Error(err)
+	}
+
+	n0 := filepath.Join(ResultsSubdirectory, w.batch.filename.String())
+
+	// avoid spurious race detections
+	fs.Lock()
+	fs.m[n0].Lock()
+
+	if len(fs.m[n0].ops) != 2 {
+		t.Error("should have had 2 ops events")
+	}
+
+	var rd record
+	err = json.Unmarshal([]byte(fs.m[n0].ops[1].data), &rd)
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	if rd != *r0 {
+		t.Error("written record should roundtrip")
+	}
+}
+
+func TestBatchWriterGrouping(t *testing.T) {
+	fs := newMemFS()
+	w := batchWriter{fs: fs}
+
+	t0 := time.Now().UTC().Truncate(0)
+	r0 := &record{ProductId: "foo", entry: entry{Price: json.Number("3.50"), Time: t0}}
+
+	t1 := time.Now().UTC().Truncate(0)
+	r1 := &record{ProductId: "foo", entry: entry{Price: json.Number("2.20"), Time: t1}, PreviousPrice: r0.Price}
+
+	err := w.writeRecord(r0)
+	if err != nil {
+		t.Error(err)
+	}
+
+	n0 := filepath.Join(ResultsSubdirectory, w.batch.filename.String())
+	fs.Lock()
+	fs.m[n0].Lock()
+	if len(fs.m[n0].ops) != 2 {
+		t.Error("should have had 2 ops events")
+	}
+	fs.m[n0].Unlock()
+	fs.Unlock()
+
+	err = w.writeRecord(r1)
+	if err != nil {
+		t.Error(err)
+	}
+
+	n1 := filepath.Join(ResultsSubdirectory, w.batch.filename.String())
+
+	if n0 == n1 {
+		t.Error("filenames should be different")
+	}
+
+	fs.Lock()
+	if _, exists := fs.m[n0]; exists {
+		t.Error("old filename should no longer exist")
+	}
+	fs.m[n1].Lock()
+	if len(fs.m[n1].ops) != 4 {
+		t.Error("should have had 4 write events")
+	}
+	fs.m[n1].Unlock()
+	fs.Unlock()
+
+	w.batch.flush()
+	<-w.batch.synced
+
+	fs.Lock()
+	fs.m[n1].Lock()
+	ops := fs.m[n1].ops
+
+	if len(ops) != 7 {
+		t.Error("should have had 7 total events")
+	}
+
+	if ops[len(ops)-2].name != "sync" {
+		t.Error("before last op should be sync")
+	}
+
+	if ops[len(ops)-1].name != "close" {
+		t.Error("last op should be close")
+	}
+}
+
+func TestBatchWriterMaxSize(t *testing.T) {
+	fs := newMemFS()
+	w := batchWriter{fs: fs}
+
+	var prevPrice json.Number
+	write := func(n int) {
+		for i := 1; i <= n; i++ {
+			p := json.Number(fmt.Sprint(i))
+			r := &record{ProductId: "foo", entry: entry{Price: p, Time: time.Now().UTC().Truncate(0)}, PreviousPrice: prevPrice}
+			prevPrice = p
+			err := w.writeRecord(r)
+			if err != nil {
+				t.Error(err)
+			}
+		}
+	}
+
+	if MaxRecordsPerFile < 3 {
+		panic("can't test batching with max size < 3")
+	}
+
+	write(1)
+	b0 := w.batch
+	write(1)
+	b1 := w.batch
+	if b0 != b1 {
+		t.Error("first two writes should have gone to the same batch")
+	}
+	select {
+	case <-b1.synced:
+		t.Error("first batch should not have been synced yet")
+	default:
+	}
+
+	write(MaxRecordsPerFile)
+
+	select {
+	case <-b1.synced:
+	case <-time.After(FlushInterval / 2):
+		t.Error("first batch should have been synced")
+	}
+
+	b2 := w.batch
+	if b2 == b1 || b2 == nil {
+		t.Error("should have started a second batch")
+	}
+	select {
+	case <-b2.synced:
+		t.Error("second batch should not have been synced yet")
+	case <-time.After(FlushInterval / 2):
+	}
+
+	write(MaxRecordsPerFile)
+	select {
+	case <-b2.synced:
+	case <-time.After(FlushInterval / 2):
+		t.Error("second batch should have been synced")
+	}
+
+	b3 := w.batch
+	if b3 == b2 || b3 == nil {
+		t.Error("should have started a third batch")
+	}
+	write(1)
+
+	select {
+	case <-b3.synced:
+		t.Error("third batch should not have been synced yet")
+	case <-time.After(FlushInterval / 2):
+	}
+
+	b4 := w.batch
+	if b4 != b3 {
+		t.Error("additional write should have gone to third batch")
+	}
+
+	select {
+	case <-b3.synced:
+	case <-time.After(FlushInterval):
+		t.Error("third batch should have been synced within FlushInterval")
+	}
+
+	write(1)
+	if b4 == w.batch {
+		t.Error("final write should have created a new batch")
+	}
+}
+
+func TestBatchWriterMonotonicity(t *testing.T) {
+	fs := newMemFS()
+	w := batchWriter{fs: fs}
+
+	t0 := time.Now().UTC().Truncate(0)
+	t1 := time.Now().UTC().Truncate(0)
+
+	r0 := &record{ProductId: "foo", entry: entry{Price: json.Number("3.50"), Time: t1}}
+	r1 := &record{ProductId: "foo", entry: entry{Price: json.Number("2.20"), Time: t0}, PreviousPrice: r0.Price}
+
+	err := w.writeRecord(r0)
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	// should panic, because non monotonic timestamps is a linearizer bug
+	// that invalidates storage directory invariants
+	var panic interface{}
+	func() {
+		defer func() { panic = recover() }()
+		_ = w.writeRecord(r1)
+	}()
+
+	if panic == nil {
+		t.Error("writing non monotonic timestamps in a batch should panic")
+	}
+}

--- a/storage/errors.go
+++ b/storage/errors.go
@@ -1,0 +1,21 @@
+package storage
+
+import (
+	"fmt"
+)
+
+type errors []error
+
+func (err errors) Error() string { return fmt.Sprintf("%+v", []error(err)) } // TODO improve formatting?
+
+func collectErrors(accum *error, new error) {
+	if new == nil {
+		return
+	} else if *accum == nil {
+		*accum = new
+	} else if errs, ok := (*accum).(errors); ok {
+		*accum = append(errs, new)
+	} else {
+		*accum = errors{*accum, new}
+	}
+}

--- a/storage/filename.go
+++ b/storage/filename.go
@@ -1,0 +1,94 @@
+package storage
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"time"
+)
+
+type filename struct {
+	fileSeq  int64
+	entrySeq int64
+
+	nRecords    int64
+	nProductIds int64
+
+	start time.Time
+}
+
+func (f filename) String() string {
+	var b strings.Builder
+	b.Grow(255) // max portable filename
+
+	// big endian for lexicographical order
+	err := binary.Write(hex.NewEncoder(&b), binary.BigEndian, []int64{
+		f.fileSeq,
+		f.entrySeq,
+		f.nRecords,
+		f.nProductIds,
+		f.start.Unix(),
+		int64(f.start.Nanosecond()),
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	b.WriteString(".json")
+
+	if b.Len() > 255 {
+		panic("filename too long, shouldn't happen")
+	}
+
+	return b.String()
+}
+
+func (f *filename) FromString(s string) (err error) {
+	b, err := hex.DecodeString(strings.TrimSuffix(s, ".json"))
+	if err != nil {
+		return err
+	}
+	r := bytes.NewReader(b)
+
+	collectErrors(&err, binary.Read(r, binary.BigEndian, &f.fileSeq))
+	collectErrors(&err, binary.Read(r, binary.BigEndian, &f.entrySeq))
+	collectErrors(&err, binary.Read(r, binary.BigEndian, &f.nRecords))
+	collectErrors(&err, binary.Read(r, binary.BigEndian, &f.nProductIds))
+
+	var unixSec, nanoSec int64
+	collectErrors(&err, binary.Read(r, binary.BigEndian, &unixSec))
+	collectErrors(&err, binary.Read(r, binary.BigEndian, &nanoSec))
+	f.start = time.Unix(unixSec, nanoSec)
+
+	return f.check()
+}
+
+type fieldError struct {
+	name  string
+	value int64
+}
+
+func (e fieldError) Error() string {
+	return fmt.Sprintf("invalid %s %d", e.name, e.value)
+}
+
+func (f filename) check() (err error) {
+	// TODO version bit?
+
+	if f.fileSeq < 1 {
+		collectErrors(&err, fieldError{"fileSeq", f.fileSeq})
+	}
+	if f.entrySeq < 1 {
+		collectErrors(&err, fieldError{"entrySeq", f.entrySeq})
+	}
+	if f.nRecords < 1 {
+		collectErrors(&err, fieldError{"nRecords", f.nRecords})
+	}
+	if f.nProductIds < 1 {
+		collectErrors(&err, fieldError{"nProductIds", f.nProductIds})
+	}
+
+	return
+}

--- a/storage/filename_test.go
+++ b/storage/filename_test.go
@@ -1,0 +1,48 @@
+package storage
+
+import (
+	"testing"
+	"time"
+)
+
+func TestFilenameCheck(t *testing.T) {
+	var f filename
+
+	if err := f.check(); err == nil {
+		t.Error("blank filename should be invalid")
+	}
+
+	f.fileSeq = 1
+	f.entrySeq = 1
+	f.nRecords = 1
+	f.nProductIds = 1
+
+	if err := f.check(); err != nil {
+		t.Error("minimum fields should be enough", err)
+	}
+}
+
+func TestFilenameString(t *testing.T) {
+	var f filename
+
+	f.fileSeq = 1
+	f.entrySeq = 1
+	f.nRecords = 1
+	f.nProductIds = 1
+	f.start = time.Now().Truncate(0)
+
+	var f2 filename
+	err := f2.FromString(f.String())
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	if f != f2 {
+		t.Error("struct data should survive round trip")
+	}
+
+	if f.String() != f2.String() {
+		t.Error("string form should be identical")
+	}
+}

--- a/storage/fs.go
+++ b/storage/fs.go
@@ -1,0 +1,30 @@
+package storage
+
+import (
+	"io"
+)
+
+// fs is the combined interface used for filesystem access
+type fs interface {
+	writeFS
+	readFS
+}
+
+type writeFS interface {
+	New(string) (appendFile, error) // O_WRONLY|O_APPEND|O_CREAT|O_EXCL
+	Link(string, string) error
+	Rename(string, string) error
+}
+
+type appendFile interface {
+	io.WriteCloser
+	Sync() error
+}
+
+type readFile io.Reader
+
+type readFS interface {
+	Open(string) (readFile, error) // readonly
+	Files() ([]string, error)      // in lexicographical order
+	Sub(string) readFS             // TODO generalize to Sub(string) fs? it's only really important for filescanning
+}

--- a/storage/fs_mem.go
+++ b/storage/fs_mem.go
@@ -1,0 +1,178 @@
+package storage
+
+import (
+	"bytes"
+	"fmt"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// memory backed implementation of filesystem interfaces, used for testing
+// snapshot consistency and to avoid writing to disk in unit tests
+type memFS struct {
+	sync.Mutex
+	m map[string]*memFile
+}
+
+var _ fs = &memFS{}
+
+func newMemFS() *memFS {
+	return &memFS{m: make(map[string]*memFile)}
+}
+
+type memFile struct {
+	sync.Mutex
+	ops []fileOp
+}
+
+type fileOp struct {
+	name string
+	data string
+}
+
+func (f *memFile) log(op fileOp) {
+	f.Lock()
+	defer f.Unlock()
+	f.ops = append(f.ops, op)
+}
+
+func (f *memFile) Write(by []byte) (int, error) {
+	f.log(fileOp{"write", string(by)})
+	return len(by), nil
+}
+func (f *memFile) Close() error {
+	f.log(fileOp{name: "close"})
+	return nil
+}
+
+func (f *memFile) Sync() error {
+	f.log(fileOp{name: "sync"})
+	return nil
+}
+
+func (m *memFS) Link(old, new string) error {
+	m.Lock()
+	defer m.Unlock()
+
+	m.m[new] = m.m[old]
+	return nil
+}
+
+func (m *memFS) Rename(old, new string) error {
+	m.Lock()
+	defer m.Unlock()
+
+	m.m[new] = m.m[old]
+	delete(m.m, old)
+	return nil
+}
+
+func (m *memFS) New(name string) (appendFile, error) {
+	m.Lock()
+	defer m.Unlock()
+
+	if _, exists := m.m[name]; exists {
+		return nil, fmt.Errorf("already exists")
+	}
+
+	f := &memFile{}
+	m.m[name] = f
+	return f, nil
+}
+
+func (m *memFS) Open(name string) (readFile, error) {
+	m.Lock()
+	file, exists := m.m[name]
+	m.Unlock()
+	if !exists {
+		return nil, fmt.Errorf("no such file")
+	}
+
+	var buf bytes.Buffer
+
+	file.Lock()
+	defer file.Unlock()
+
+	for _, op := range file.ops {
+		switch op.name {
+		case "write":
+			buf.WriteString(op.data)
+		default:
+		}
+	}
+
+	return &buf, nil
+}
+
+func (m *memFS) Files() ([]string, error) {
+	files, err := m.allFiles()
+	basenames := make([]string, 0, len(files))
+
+	for _, name := range files {
+		if strings.IndexByte(name, filepath.Separator) == -1 {
+			basenames = append(basenames, name)
+		}
+	}
+
+	return basenames, err
+}
+
+func (m *memFS) allFiles() ([]string, error) {
+	m.Lock()
+	defer m.Unlock()
+
+	names := make([]string, 0, len(m.m))
+	for name := range m.m {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+func (m *memFS) Sub(name string) readFS {
+	return subMemFS{name, m}
+}
+
+func (src *memFS) clone() *memFS {
+	src.Lock()
+	defer src.Unlock()
+
+	dst := newMemFS()
+	for key, value := range src.m {
+		value.Lock()
+		dst.m[key] = &memFile{ops: append([]fileOp{}, value.ops...)}
+		value.Unlock()
+	}
+	return dst
+}
+
+type subMemFS struct {
+	prefix string
+	inner  *memFS
+}
+
+func (s subMemFS) Sub(name string) readFS {
+	return s.inner.Sub(path.Join(s.prefix, name))
+}
+
+func (s subMemFS) Open(name string) (readFile, error) {
+	return s.inner.Open(path.Join(s.prefix, name))
+}
+
+func (s subMemFS) Files() ([]string, error) {
+	files, err := s.inner.allFiles()
+	start := sort.SearchStrings(files, s.prefix+string(filepath.Separator))
+	end := sort.SearchStrings(files, s.prefix+string(filepath.Separator+1))
+
+	files = files[start:end]
+
+	// trim prefix off
+	for i, v := range files {
+		files[i] = v[len(s.prefix)+1:]
+	}
+
+	return files, err
+}

--- a/storage/fs_os.go
+++ b/storage/fs_os.go
@@ -1,0 +1,78 @@
+package storage
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+func OS(dir string) fs {
+	return osFS(dir)
+}
+
+type osFS string
+
+func (base osFS) filename(filename string) string {
+	return filepath.Join(string(base), filename)
+}
+
+func (base osFS) Link(old, new string) error {
+	err := os.MkdirAll(filepath.Dir(base.filename(new)), 0777)
+	if err != nil {
+		return err
+	}
+
+	return os.Link(base.filename(old), base.filename(new))
+}
+
+func (base osFS) Rename(old, new string) error {
+	err := os.MkdirAll(filepath.Dir(base.filename(new)), 0777)
+	if err != nil {
+		return err
+	}
+
+	return os.Rename(base.filename(old), base.filename(new))
+}
+
+func (base osFS) New(name string) (appendFile, error) {
+	target := base.filename(name)
+
+	err := os.MkdirAll(filepath.Dir(target), 0777)
+	if err != nil {
+		return nil, err
+	}
+
+	if f, err := os.OpenFile(target, os.O_APPEND|os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0644); f != nil {
+		return f, err
+	} else {
+		return nil, err
+	}
+}
+
+func (base osFS) Open(name string) (readFile, error) {
+	if f, err := os.Open(base.filename(name)); f != nil {
+		return f, err
+	} else {
+		return nil, err
+	}
+}
+
+func (base osFS) Files() ([]string, error) {
+	f, err := os.Open(string(base))
+	if err != nil {
+		if _, ok := err.(*os.PathError); ok || !os.IsNotExist(err) {
+			// from the the domain POV these are not errors, just null data
+			err = nil
+		}
+
+		return nil, err
+	}
+
+	names, err := f.Readdirnames(-1)
+	sort.Strings(names)
+	return names, err
+}
+
+func (base osFS) Sub(name string) readFS {
+	return osFS(base.filename(name))
+}

--- a/storage/fs_test.go
+++ b/storage/fs_test.go
@@ -1,0 +1,160 @@
+package storage
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// table driven tests to check osFS and memFS parity
+var tests = []struct {
+	name string
+	body func(t *testing.T, fs fs)
+}{
+	{"initial", func(t *testing.T, fs fs) {
+		files, err := fs.Files()
+		if err != nil {
+			t.Error(err)
+		}
+
+		if len(files) != 0 {
+			t.Error("uninitialized fs should have no files")
+		}
+
+		f, err := fs.Open("foo")
+		if err == nil || f != nil {
+			t.Error("opening non existent file should return no reader and an error", err, f)
+		}
+	}},
+	{"write", func(t *testing.T, fs fs) {
+		w, err := fs.New("foo")
+		if err != nil || w == nil {
+			t.Error("new file should have been opened successfully", err)
+		}
+
+		_, _ = w.Write([]byte("important\n"))
+		_ = w.Sync()
+		_ = w.Close()
+
+		files, err := fs.Files()
+		if err != nil {
+			t.Error(err)
+		}
+
+		if len(files) != 1 || files[0] != "foo" {
+			t.Error("the new file should be in the list", fmt.Sprintf("%#v", files))
+		}
+
+		w2, err := fs.New("foo")
+		if err == nil || w2 != nil {
+			t.Error("creating duplicate file should return no writer and an error", err, w2)
+		}
+
+		r, err := fs.Open("foo")
+		if err != nil || r == nil {
+			t.Error("written file should have been opened successfully", err)
+		}
+
+		b, err := ioutil.ReadAll(r)
+		if err != nil {
+			t.Error(err)
+		}
+		if string(b) != "important\n" {
+			t.Error("contents of file were not preserved")
+		}
+	}},
+	{"several", func(t *testing.T, fs fs) {
+		w1, _ := fs.New("foo")
+		files, _ := fs.Files()
+		if len(files) != 1 {
+			t.Error("the new file should be in the list")
+		}
+
+		_, _ = w1.Write([]byte("first\n"))
+
+		w2, _ := fs.New("bar")
+		files, _ = fs.Files()
+		if len(files) != 2 {
+			t.Error("second new file should be in the list")
+		}
+
+		_, _ = w2.Write([]byte("second\n"))
+		_, _ = w1.Write([]byte("third\n"))
+
+		_ = w2.Sync()
+		_ = w2.Close()
+
+		_ = w1.Sync()
+		_ = w1.Close()
+
+		files, _ = fs.Files()
+		if len(files) != 2 {
+			t.Error("second new file should be in the list")
+		}
+
+		r1, err := fs.Open("foo")
+		if err != nil || r1 == nil {
+			t.Error("written file should have been opened successfully", err)
+		}
+
+		b1, err := ioutil.ReadAll(r1)
+		if err != nil {
+			t.Error(err)
+		}
+		if string(b1) != "first\nthird\n" {
+			t.Error("contents of file were not preserved")
+		}
+
+		r2, err := fs.Open("bar")
+		if err != nil || r2 == nil {
+			t.Error("written file should have been opened successfully", err)
+		}
+
+		b2, err := ioutil.ReadAll(r2)
+		if err != nil {
+			t.Error(err)
+		}
+		if string(b2) != "second\n" {
+			t.Error("contents of file were not preserved")
+		}
+	}},
+
+	// TODO
+	// filenames with slashes in them
+	// Link
+	// Rename
+	// Sub
+	// link counts
+
+}
+
+func TestFS(t *testing.T) {
+	tmpDir, err := ioutil.TempDir(".", "fs-test-tmpdir-")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer os.RemoveAll(tmpDir)
+
+	for fsname, fs := range map[string]func(name string) fs{
+		"memfs": func(_ string) fs { return newMemFS() },
+		"os": func(name string) fs {
+			dir := filepath.Join(tmpDir, name)
+			err := os.MkdirAll(dir, 0777)
+			if err != nil {
+				t.Fatal(err)
+			}
+			return osFS(dir)
+		},
+	} {
+		t.Run(fsname, func(t *testing.T) {
+			for _, test := range tests {
+				t.Run(test.name, func(t *testing.T) {
+					test.body(t, fs(test.name))
+				})
+			}
+		})
+	}
+}

--- a/storage/hash.go
+++ b/storage/hash.go
@@ -1,0 +1,14 @@
+package storage
+
+import (
+	"crypto/sha256"
+	"fmt"
+)
+
+// TODO type ProductId string
+
+func ProductIdHash(productId string) string {
+	// we need to hash the productId because there's
+	// no length constraint on the input and file names are limited
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(productId)))
+}

--- a/storage/linearizer.go
+++ b/storage/linearizer.go
@@ -1,0 +1,339 @@
+package storage
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+const WriteQueueLength = 50
+
+type Log interface{ Log(...interface{}) }
+
+// linearizedState is stacks an a partial in memory priceModel on top of a read
+// only snapshot, to manage consistent population of `previousPrice` in records
+// before being written to storage
+//
+// construct with linearizeUpdates()
+type linearizedState struct {
+	mem priceReader
+
+	newPriceRecords   chan *record
+	lastPriceRequests chan lastPriceRequest
+}
+
+var _ priceModel = linearizedState{}
+
+// linearizeUpdates will, given:
+// - `mem`, a priceModel used synchronously (ideally nonblocking) TODO interface with LoadOrStore semantics
+// - `snapshot`, a priceReader used async defining initial last prices state
+// - `persistent`, a sink for finalized price records
+// returns a priceModel which will:
+// - provides a RW view that shadows/overlays `mem` on top of `snapshot`
+// - fill in consistent `previousPrice` values for updates and output to `persistent`
+func linearizeUpdates(mem priceState, snapshot priceReader, persistent recordWriter) priceModel {
+	// WriteQueueLength is split between two buffered channels: // TODO expose len() as metric
+	newPriceRecords := make(chan *record, WriteQueueLength/2) // avoid failing nonblocking UpdatePrice() calls due to minor contention
+	writeQueue := make(chan chan *record, WriteQueueLength/2) // avoid avoid blocking linearizer loop due to write contention pending previousPrice
+
+	// no need to buffer read requests
+	lastPriceRequests := make(chan lastPriceRequest) // TODO expose len() as metric
+
+	// capture channels needed for implementing model interface as member variables
+	l := linearizedState{
+		mem:               mem,
+		newPriceRecords:   newPriceRecords,
+		lastPriceRequests: lastPriceRequests,
+	}
+
+	// TODO capture errors from both loop goroutines
+	go l.flushWrites(persistent, writeQueue)
+	go l.linearizeOperations(mem, snapshot, writeQueue, newPriceRecords, lastPriceRequests)
+
+	return l
+}
+
+// this loop waits for records to be finalized and then passes them on to
+// persistent storage.
+func (linearizedState) flushWrites(persistent recordWriter, writeQueue <-chan chan *record) {
+	// process the write queue in order
+	for c := range writeQueue {
+		// wait for individual records
+		rec := <-c
+
+		// perform a blocking write
+		_ = persistent.writeRecord(rec)
+
+		// TODO
+		// - handle errors from writer
+		// - pass chan struct{} to propagate notification of file sync
+	}
+}
+
+type lastPriceRequest struct {
+	productId string
+	result    chan entry
+}
+
+type prevPriceRequest struct {
+	productId string
+	result    chan json.Number
+}
+
+// this loop linearizes all operations to create a total ordering of state
+// updates and reads which are satisfied from memory or from disk
+// the only potentially blocking operation should be writing to the writeQueue
+// buffer when entries are finalized
+//
+// *records written into newPriceRecords will be used to update the last known price
+// and will have their `previousPrice` set before being written back into
+// writeQueue.
+//
+// during this interval the underlying struct is considered to be owned by the
+// linearizer goroutine, which will make mutations to it, and should not be
+// accessed by other goroutines
+func (linearizedState) linearizeOperations(
+	mem priceState,
+	snapshot priceReader,
+	writeQueue chan<- chan *record,
+	newPriceRecords <-chan *record,
+	lastPriceRequests <-chan lastPriceRequest,
+) {
+	// internal state variables to track requests by productId
+	prevPriceListener := make(map[string]chan json.Number)
+	lastPriceListeners := make(map[string][]chan entry)
+
+	// internal channels for mananging in ongoing snapshot read requests
+	// these are buffered so that they never cause the loop to block to
+	// avoid needing to spawn additional goroutines
+	prevPriceLoaded := make(chan *record, WriteQueueLength+1)
+	prevPriceRequests := make(chan prevPriceRequest, WriteQueueLength+1)
+
+	for {
+		// case <-ctx.Cancel:
+		// TODO handle shutdown?
+		select {
+		case req := <-lastPriceRequests: // FIXME how do these get created
+			// start an inconsistent reads operation, returns latest
+			// price from memory, disk or new reprice requests
+			if price, time, _ := mem.LastPrice(req.productId); price != NullPrice { // TODO handle error
+				// this is not redundant with mem.LastPrice outside of this
+				// goroutine because other writes may have been
+				// processed by this time
+				req.result <- entry{price, time}
+			} else {
+				// register result channel
+				lastPriceListeners[req.productId] = append(lastPriceListeners[req.productId], req.result)
+
+				// make a new snapshot read to satisfy this
+				// request
+
+				// since prevPriceRequests is buffered, and
+				// there can never be more than WriteQueueLength
+				// requests, this channel write will not block,
+				// but if this ever changes this may deadlock
+				// and will need to be wrapped in a new goro
+				prevPriceRequests <- prevPriceRequest{req.productId, make(chan json.Number, 1)}
+
+				// no cancellation context is necessary
+				// because if this last price request is
+				// satisfied by a price update the result of
+				// the snapshot read will still be needed for
+				// previousPrice.
+				//
+				// if no `reprice` request occurs by the time
+				// the read is satisfied, the price will be
+				// stored in memory and this request will be simply
+				// garbage collected, but if it is needed then that
+				// request will be borrowed for signalling
+				// finalization
+			}
+		case req := <-prevPriceRequests:
+			// log.Log("previous price request for", req.productId)
+			// start a snapshot read operation.
+			// snapshot reads return the price prior to handling
+			// any new `reprice` requests in this process
+
+			// requests are triggered by a LastPrice miss on mem,
+			// which can be initiated by either a reprice request
+			// (needed for `previousPrice`) or `price` request.
+			// in the case of a `price` request, if a `reprice`
+			// request follows before the request can be satisfied
+			// we consolidate them using this map
+			//
+			// for `price` requests following `reprice` in memory
+			// data will always be served since the last reprice
+			// input is the last known price (TODO for consistent
+			// reads from `price` endpoint, in memory state should
+			// only be updated after Sync)
+			//
+			// for isolated `price` requests, the old data wil be
+			// pre-loaded into the sync map for use by subsequent
+			// `price` and `reprice` requests
+
+			if _, exists := prevPriceListener[req.productId]; exists {
+				// this shouldn't happen because the LastPrice()
+				// operation inside the loop should have succeded
+				// there should never be 2 previous price
+				// requests per process, let alone concurrently
+				panic("bug: no snapshot read should have been in progress")
+			}
+
+			prevPriceListener[req.productId] = req.result
+
+			// perform the blocking read in a new goroutine
+			go func() {
+				prevRec := &record{ProductId: req.productId}
+				prevRec.entry.Price, prevRec.entry.Time, _ = snapshot.LastPrice(req.productId) // TODO handle errors
+				// log.Log("read", *prevRec, "from snapshot")
+
+				// results can be made available immediately
+				// `previousPrice` assignments to unblock any
+				// writes
+				req.result <- prevRec.entry.Price
+
+				// clean up needs to happen synchronously, so
+				// it's handled in the main loop in the next
+				// select case
+				prevPriceLoaded <- prevRec
+			}()
+		case prevRec := <-prevPriceLoaded:
+			// log.Log("previous price data loaded", *prevRec)
+			// synchronous continuation of loadSnapshotPrice
+
+			// if a value is already in memory it originates
+			// from a more recent rewrite request, only set the
+			// loaded price if none exists
+			// it is safe to read and then write non atomically
+			// because all writes are serialized by this goroutine
+			// but sync.Map already provides LoadOrStore so we use
+			// IfMissing variant
+			_ = mem.SetPriceIfMissing(prevRec.ProductId, prevRec.entry.Price, prevRec.entry.Time) // TODO handle errors
+
+			// remove listener, the result has already been written
+			// to it in the background goroutine
+			delete(prevPriceListener, prevRec.ProductId)
+
+			// inconsistent readers need to be notified from the loop
+			// goroutine (here) since the lastPriceListeners map &
+			// slice have no synchronization primitives
+			for _, resultChan := range lastPriceListeners[prevRec.ProductId] {
+				resultChan <- prevRec.entry
+			}
+			delete(lastPriceListeners, prevRec.ProductId)
+		case rec := <-newPriceRecords:
+			// assign the canonical timestamp for a given reprice event
+			// this assumes the OS clock is monotonic
+			// FIXME preserve monotonic clock data to maintain
+			// storage invariants on systems with a clock that can
+			// go backwards
+			rec.entry.Time = time.Now()
+			// log.Log("assigned time", rec.entry.Time)
+
+			// when the entry has a `previousValue` set it can be
+			// written to persistent storage, signalled by `finalized`
+			result := make(chan *record, 1)
+
+			// store the new price in memory but first preserve any
+			// previous value already in memory
+			hasPrice := mem.HasPrice(rec.ProductId)             // FIXME remove
+			previousPrice, _, _ := mem.LastPrice(rec.ProductId) // TODO handle errors
+
+			// log.Log("memory has prev price?", hasPrice, previousPrice)
+
+			// TODO for consistent `price` endpoint reads, this write
+			// needs to be delayed until sync
+			_ = mem.SetPrice(rec.ProductId, rec.entry.Price, rec.entry.Time)
+
+			// finalize the `previousPrice` field
+			if hasPrice { // TODO snapshot null prices are written back to memory, use them
+				// non-blocking write path, set it and mark final immediately
+				// log.Log("setting previous price from memory")
+				rec.PreviousPrice = previousPrice // FIXME nullableNumber is an ugly type
+				result <- rec
+			} else {
+				// log.Log("fetching previous price")
+				// blocking path, need to wait for previous price
+				var prevPriceResult chan json.Number
+
+				if inFlightResult, exists := prevPriceListener[rec.ProductId]; exists {
+					// log.Log("borrowing")
+					// a snapshot read is already in progress due
+					// to a `price` request, so we can just use its
+					// result to finalize
+					prevPriceResult = inFlightResult
+
+					// independently, we can notify the
+					// requests that are waiting for that data
+					// that a more recent price is available
+					for _, result := range lastPriceListeners[rec.ProductId] {
+						// TODO for consistent `price` endpoint
+						// reads, this needs to be deferred
+						// until the data is written (or synced)
+						// to disk
+						result <- rec.entry // this should never block
+					}
+					delete(lastPriceListeners, rec.ProductId)
+				} else {
+					// log.Log("making previous price request")
+					// no load operation in progress, start one
+					prevPriceResult = make(chan json.Number, 1)
+					prevPriceRequests <- prevPriceRequest{rec.ProductId, prevPriceResult}
+				}
+
+				// in either case, wait for the price data
+				// and then mark the record final
+				go func() {
+					rec.PreviousPrice = <-prevPriceResult // FIXME nullableNumber is an ugly type
+					// log.Log("got previous price", *rec)
+					result <- rec
+				}()
+			}
+
+			// always queue the records for writing in order as per
+			// https://golang.org/ref/spec#Channel_types
+			// since writeQueue is buffered, this should only block
+			// due to backpressure from write loop
+			writeQueue <- result
+
+			// TODO make(chan struct{}) and associate with *record
+			// to track syncs for managing consistent reads
+		}
+	}
+}
+
+func (l linearizedState) HasPrice(productId string) bool { return false } // FIXME remove by LastPrice(string) (*Entry, error)
+
+// LastPrice provides the last known price of a given product (including non-durable state)
+func (l linearizedState) LastPrice(productId string) (json.Number, time.Time, error) {
+	// since productReader interface is concurrency safe, we first try to
+	// satisfy a read from memory
+	if price, time, err := l.mem.LastPrice(productId); price != NullPrice || err != nil {
+		return price, time, err
+	}
+
+	// on miss, add a request to be handled by the linearizer loop
+	result := make(chan entry, 1)
+	l.lastPriceRequests <- lastPriceRequest{productId, result}
+
+	// wait for request to be satisfied
+	ent := <-result
+	return ent.Price, ent.Time, nil
+}
+
+// UpdatePrice updates in memory price and queus a record for writing when processed.
+//
+// This implementation is non-blocking and will return an error when no writes
+// can be accepted.
+func (l linearizedState) UpdatePrice(productId string, price json.Number) error {
+	select {
+	case l.newPriceRecords <- &record{
+		ProductId: productId,
+		entry:     entry{Price: price},
+	}:
+		return nil
+	default:
+		// TODO add a blocking writer for completeness?
+		return fmt.Errorf("write capacity exceeded") // TODO interface { Temporary() bool } for correct 503 vs. 500 code
+	}
+}

--- a/storage/linearizer_test.go
+++ b/storage/linearizer_test.go
@@ -96,7 +96,10 @@ func TestLinearizerPriorData(t *testing.T) {
 	mem := simpleMap{" mem", t, make(map[string]entry)}
 	snap := simpleMap{"snap", t, make(map[string]entry)}
 
-	t0 := time.Now()
+	// truncate monotonic time component, which is not serialized in JSON
+	// and provide explicit timezone to match JSON deserialization loc
+	t0 := time.Now().UTC().Truncate(0)
+
 	_ = snap.SetPrice("foo", json.Number("4.20"), t0)
 
 	model := linearizeUpdates(mem, snap, writes)

--- a/storage/linearizer_test.go
+++ b/storage/linearizer_test.go
@@ -1,0 +1,286 @@
+package storage
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+// unit test linearization of state only?
+// or entire storage component?
+
+func TestLinearizerSanity(t *testing.T) {
+	writes := make(chanRecordWriter, 1)
+	mem := simpleMap{"mem", t, make(map[string]entry)}
+
+	model := linearizeUpdates(mem, noop{}, writes)
+
+	price, timestamp, err := model.LastPrice("foo")
+	if err != nil {
+		t.Error(err)
+	}
+	if (price != NullPrice || timestamp != time.Time{}) {
+		t.Error("should have gotten no data from linearized state model")
+	}
+
+	t.Log("setting foo")
+	err = model.UpdatePrice("foo", json.Number("3.50"))
+	if err != nil {
+		t.Error(err)
+	}
+
+	<-writes
+
+	price0, t0, err := model.LastPrice("foo")
+	if err != nil {
+		t.Error(err)
+	}
+	if (price0 != json.Number("3.50") || t0 == time.Time{}) {
+		t.Error("should have gotten stored data from linearized state model")
+	}
+}
+
+func TestLinearizerUpdateSanity(t *testing.T) {
+	writes := make(chanRecordWriter, 1)
+	mem := simpleMap{"mem", t, make(map[string]entry)}
+
+	model := linearizeUpdates(mem, noop{}, writes)
+
+	t.Log("setting foo")
+	err := model.UpdatePrice("foo", json.Number("3.50"))
+	if err != nil {
+		t.Error(err)
+	}
+
+	rec := <-writes
+	if rec.entry.Price != json.Number("3.50") {
+		t.Error("written price should have been that of input")
+	}
+
+	price0, t0, err := model.LastPrice("foo")
+	if err != nil {
+		t.Error(err)
+	}
+	if (price0 != json.Number("3.50") || t0 == time.Time{}) {
+		t.Error("should have gotten stored data from linearized state model")
+	}
+
+	t.Log("updating foo")
+	err = model.UpdatePrice("foo", json.Number("2.20"))
+	if err != nil {
+		t.Error(err)
+	}
+
+	rec = <-writes
+	if rec.entry.Price != json.Number("2.20") {
+		t.Error("written price should have been that of input")
+	}
+
+	price, t1, err := model.LastPrice("foo")
+	if err != nil {
+		t.Error(err)
+	}
+	if price != json.Number("2.20") || t1.Before(t0) {
+		t.Error("should have gotten updated data with later time from linearized state model", price, t0, t1)
+	}
+
+	select {
+	case <-writes:
+		t.Error("no further writes should have been made")
+	default:
+	}
+}
+
+func TestLinearizerPriorData(t *testing.T) {
+	writes := make(chanRecordWriter, 1)
+	mem := simpleMap{" mem", t, make(map[string]entry)}
+	snap := simpleMap{"snap", t, make(map[string]entry)}
+
+	t0 := time.Now()
+	_ = snap.SetPrice("foo", json.Number("4.20"), t0)
+
+	model := linearizeUpdates(mem, snap, writes)
+
+	price, t1, err := model.LastPrice("foo")
+	if err != nil {
+		t.Error(err)
+	}
+	if price != json.Number("4.20") || t1.Before(t0) {
+		t.Error("should have gotten prior data from snapshot")
+	}
+
+	t.Log("setting foo")
+	err = model.UpdatePrice("foo", json.Number("3.50"))
+	if err != nil {
+		t.Error(err)
+	}
+
+	<-writes
+
+	price0, t2, err := model.LastPrice("foo")
+	if err != nil {
+		t.Error(err)
+	}
+	if price0 != json.Number("3.50") || t2.Before(t1) {
+		t.Error("should have gotten stored data from linearized state model")
+	}
+}
+
+func TestLinearizerConcurrentRead(t *testing.T) {
+	writes := make(chanRecordWriter, 1)
+	mem := simpleMap{" mem", t, make(map[string]entry)}
+	snap := simpleMap{"snap", t, make(map[string]entry)}
+	release := make(chan struct{})
+
+	t0 := time.Now()
+	_ = snap.SetPrice("foo", json.Number("4.20"), t0)
+
+	model := linearizeUpdates(mem, syncReader{snap, release}, writes)
+
+	lastPriceChan := make(chan entry)
+
+	go func() {
+		price, t1, err := model.LastPrice("foo")
+		if err != nil {
+			t.Error(err)
+		}
+		if price != json.Number("3.50") || t1.Before(t0) {
+			t.Error("should have gotten new data from subsequent update", price, t1)
+		}
+
+		lastPriceChan <- entry{price, t1}
+	}()
+
+	// ensure read request starts
+	release <- struct{}{}
+
+	go func() {
+		err := model.UpdatePrice("foo", json.Number("3.50"))
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+
+	var t1 time.Time
+
+	// the LastPrice call should return immediately upon updating
+	select {
+	case ent := <-lastPriceChan:
+		if ent.Price != json.Number("3.50") {
+			t.Error("last price should have been from update")
+		}
+
+		t1 = ent.Time
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for last price response")
+	}
+
+	select {
+	case <-writes:
+		t.Error("no data should have been written yet")
+	case <-time.After(time.Millisecond):
+	}
+
+	// return from snap.LastReader, to release write
+	<-release
+
+	select {
+	case rec := <-writes:
+		if rec.entry.Price != json.Number("3.50") {
+			t.Error("written record should have had newPrice specified in update")
+		}
+		if rec.PreviousPrice != json.Number("4.20") {
+			t.Error("record should have previousPrice from snapshot")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for write")
+	}
+
+	// Ensure the new value can be read without requiring the snapshot to be
+	// released again
+	c := make(chan struct{})
+	go func() {
+		price0, t2, err := model.LastPrice("foo")
+		if err != nil {
+			t.Error(err)
+		}
+		if price0 != json.Number("3.50") || t2.Before(t1) {
+			t.Error("should have gotten stored data from linearized state model")
+		}
+		close(c)
+	}()
+
+	select {
+	case <-c:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for in memory read")
+	}
+}
+
+/*
+t0   - get last price foo - in memory miss
+t0+e - last price from disk - 3.50@t-3
+t0+e - serve 3.50@t-3
+
+t0   - get  foo - last price foo - in memory miss miss
+t1   - post foo - queue finalize foo 3.50@t0 - previousPrice still blocking -- can only queue finalization *once* per product Id - subsequent prices will always be known
+t1+e - serve last price 3.50@t0 - get request terminates
+t1+e - queue write foo 1.23@t1 - previousPrice 3.50@t0 but write still blocking
+t1+e - last price fromdisk - 2.20@t-2
+t1+e - write foo 3.50@t0, previousPrice 2.20@t-2 - flushed
+t1+e - write foo 1.23@t0, previousPrice 3.50@t0  */
+
+type noop struct{}
+
+func (noop) UpdatePrice(_ string, _ json.Number) error                { return nil }
+func (noop) HasPrice(_ string) bool                                   { return false }
+func (noop) LastPrice(_ string) (_ json.Number, _ time.Time, _ error) { return }
+func (noop) SetPrice(_ string, _ json.Number, _ time.Time) error      { return nil }
+
+type simpleMap struct {
+	name string
+	*testing.T
+	data map[string]entry
+}
+
+func (m simpleMap) SetPrice(productId string, price json.Number, t time.Time) error {
+	m.data[productId] = entry{price, t}
+	m.Log("->", m.name, productId, m.data[productId])
+	return nil
+}
+
+func (m simpleMap) SetPriceIfMissing(productId string, price json.Number, t time.Time) error {
+	if x, exists := m.data[productId]; exists {
+		m.Log("-|", m.name, productId, price, t, "(already set to", x, ")")
+		return nil
+	}
+	return m.SetPrice(productId, price, t)
+}
+
+func (m simpleMap) LastPrice(productId string) (json.Number, time.Time, error) {
+	ent := m.data[productId]
+	m.Log("<-", m.name, productId, ent)
+	return ent.Price, ent.Time, nil
+}
+
+func (m simpleMap) HasPrice(productId string) (ret bool) {
+	_, ret = m.data[productId]
+	return
+}
+
+type chanRecordWriter chan *record
+
+func (c chanRecordWriter) writeRecord(r *record) error {
+	c <- r
+	return nil
+}
+
+type syncReader struct {
+	priceReader
+	wait chan struct{}
+}
+
+func (r syncReader) LastPrice(productId string) (json.Number, time.Time, error) {
+	r.wait <- <-r.wait // pass token
+	return r.priceReader.LastPrice(productId)
+}

--- a/storage/linearizer_test.go
+++ b/storage/linearizer_test.go
@@ -174,7 +174,7 @@ func TestLinearizerConcurrentRead(t *testing.T) {
 		}
 
 		t1 = ent.Time
-	case <-time.After(time.Second):
+	case <-time.After(2 * FlushInterval):
 		t.Fatal("timed out waiting for last price response")
 	}
 
@@ -195,7 +195,7 @@ func TestLinearizerConcurrentRead(t *testing.T) {
 		if rec.PreviousPrice != json.Number("4.20") {
 			t.Error("record should have previousPrice from snapshot")
 		}
-	case <-time.After(time.Second):
+	case <-time.After(2 * FlushInterval):
 		t.Fatal("timed out waiting for write")
 	}
 
@@ -215,7 +215,7 @@ func TestLinearizerConcurrentRead(t *testing.T) {
 
 	select {
 	case <-c:
-	case <-time.After(time.Second):
+	case <-time.After(2 * FlushInterval):
 		t.Fatal("timed out waiting for in memory read")
 	}
 }

--- a/storage/loader.go
+++ b/storage/loader.go
@@ -1,0 +1,47 @@
+package storage
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"time"
+)
+
+// priceLoader provides a priceReader interface from a readerFS
+type priceLoader struct{ readFS }
+
+var _ priceReader = priceLoader{}
+
+func (s priceLoader) HasPrice(_ string) bool { return false } // FIXME refactor
+func (s priceLoader) LastPrice(productId string) (p json.Number, t time.Time, err error) {
+	d := s.readFS.Sub(filepath.Join(ProductSubdirectory, ProductIdHash(productId)))
+
+	files, err := d.Files()
+	if err != nil {
+		return
+	}
+
+	if len(files) == 0 {
+		return
+	}
+
+	lastFile := files[len(files)-1] // TODO func LastFile(readFS) string which checks for d.LastFile and to do this more cheaply?
+
+	f, err := d.Open(lastFile)
+	if err != nil {
+		return
+	}
+
+	var r []record
+	err = json.NewDecoder(f).Decode(&r)
+	if err != nil {
+		return
+	}
+
+	for i := len(r) - 1; i >= 0; i-- {
+		if r[i].ProductId == productId {
+			return r[i].Price, r[i].Time, nil
+		}
+	}
+
+	panic("should have found product")
+}

--- a/storage/memory.go
+++ b/storage/memory.go
@@ -1,0 +1,30 @@
+package storage
+
+import (
+	"encoding/json"
+	"sync"
+	"time"
+)
+
+func New() interface {
+	UpdatePrice(string, json.Number) error
+	LastPrice(string) (json.Number, time.Time, error)
+} {
+	return &store{}
+}
+
+type store struct{ sync.Map }
+
+func (s *store) UpdatePrice(productId string, price json.Number) error {
+	s.Map.Store(productId, &entry{price, time.Now()})
+	return nil
+}
+
+func (s *store) LastPrice(productId string) (json.Number, time.Time, error) {
+	if ent, exists := s.Map.Load(productId); exists {
+		ent := ent.(*entry)
+		return ent.Price, ent.Time, nil
+	} else {
+		return json.Number(""), time.Time{}, nil
+	}
+}

--- a/storage/model.go
+++ b/storage/model.go
@@ -25,6 +25,7 @@ type priceUpdater interface {
 }
 
 type priceReader interface {
+	HasPrice(string) bool
 	LastPrice(string) (json.Number, time.Time, error) // TODO(bikeshedding): (Entry, error) ?  (*Entry, error) to eliminate HasPrice?
 }
 

--- a/storage/model.go
+++ b/storage/model.go
@@ -10,13 +10,13 @@ const (
 )
 
 type entry struct {
-	Price json.Number
-	time.Time
+	Price json.Number `json:"newPrice"`
+	Time  time.Time   `json:"timestamp"` // TODO rename Timestamp
 }
 
 type record struct {
-	ProductId     string
-	PreviousPrice json.Number
+	ProductId     string      `json:"productId"`
+	PreviousPrice json.Number `json:"previousPrice,omitempty"`
 	entry
 }
 

--- a/storage/model.go
+++ b/storage/model.go
@@ -5,6 +5,10 @@ import (
 	"time"
 )
 
+const (
+	NullPrice = json.Number("")
+)
+
 type entry struct {
 	Price json.Number
 	time.Time

--- a/storage/model.go
+++ b/storage/model.go
@@ -2,12 +2,22 @@ package storage
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"time"
 )
 
 const (
 	NullPrice = json.Number("")
 )
+
+func New(path string) priceModel { // TODO return error, plumb errors & context
+	err := os.MkdirAll(filepath.Join(path, ResultsSubdirectory), 0777)
+	if err != nil {
+		panic(err)
+	}
+	return newFromFS(osFS(path))
+}
 
 type entry struct {
 	Price json.Number `json:"newPrice"`

--- a/storage/model.go
+++ b/storage/model.go
@@ -2,7 +2,6 @@ package storage
 
 import (
 	"encoding/json"
-	"sync"
 	"time"
 )
 
@@ -11,25 +10,40 @@ type entry struct {
 	time.Time
 }
 
-func New() interface {
-	UpdatePrice(string, json.Number) error
-	LastPrice(string) (json.Number, time.Time, error)
-} {
-	return &store{}
+type record struct {
+	ProductId     string
+	PreviousPrice json.Number
+	entry
 }
 
-type store struct{ sync.Map }
-
-func (s *store) UpdatePrice(productId string, price json.Number) error {
-	s.Map.Store(productId, &entry{price, time.Now()})
-	return nil
+type priceUpdater interface {
+	UpdatePrice(productId string, price json.Number) error
 }
 
-func (s *store) LastPrice(productId string) (json.Number, time.Time, error) {
-	if ent, exists := s.Map.Load(productId); exists {
-		ent := ent.(*entry)
-		return ent.Price, ent.Time, nil
-	} else {
-		return json.Number(""), time.Time{}, nil
-	}
+type priceReader interface {
+	LastPrice(string) (json.Number, time.Time, error) // TODO(bikeshedding): (Entry, error) ?  (*Entry, error) to eliminate HasPrice?
+}
+
+type priceSetter interface {
+	SetPrice(productId string, price json.Number, timestamp time.Time) error
+}
+
+type priceSetterAtomic interface {
+	SetPriceIfMissing(productId string, price json.Number, timestamp time.Time) error
+}
+
+type recordWriter interface {
+	writeRecord(record *record /*TODO chan struct{} closed on sync */) error
+}
+
+type priceState interface {
+	priceReader
+	priceSetter
+	priceSetterAtomic
+}
+
+// price resource model, consumed by REST api
+type priceModel interface {
+	priceReader
+	priceUpdater
 }

--- a/storage/snapshot.go
+++ b/storage/snapshot.go
@@ -1,0 +1,29 @@
+package storage
+
+import (
+	"sort"
+)
+
+// a filesystem that only lists filenames less than some upper bound
+type snapshotFS struct {
+	bound string
+	readFS
+}
+
+var _ readFS = snapshotFS{}
+
+func (s snapshotFS) Files() ([]string, error) {
+	raw, err := s.readFS.Files()
+	if err != nil {
+		return nil, err
+	}
+
+	return raw[0:sort.SearchStrings(raw, s.bound)], nil
+}
+
+func (s snapshotFS) Sub(name string) readFS {
+	return snapshotFS{
+		bound:  s.bound,
+		readFS: s.readFS.Sub(name),
+	}
+}

--- a/storage/startup.go
+++ b/storage/startup.go
@@ -1,0 +1,38 @@
+package storage
+
+func newFromFS(fs fs) priceModel { // TODO return error
+
+	memstore := &memStore{}
+	batchWriter := &batchWriter{fs: fs}
+	var previousPrices priceReader = memstore // TODO null store?
+
+	// TODO check link count consistency
+	// TODO check nRrecords fields and rename appropriately
+	// TODO entrySeq's for product directories? do lazily...
+
+	// restore sequence numbers from results directory
+	files, err := fs.Sub(ResultsSubdirectory).Files()
+	if err != nil {
+		panic(err)
+	}
+	if len(files) > 0 {
+		var f filename
+		err := f.FromString(files[len(files)-1])
+		if err != nil {
+			panic(err)
+		}
+
+		previousPrices = priceLoader{
+			snapshotFS{
+				bound:  filename{fileSeq: f.fileSeq + 1}.String(),
+				readFS: fs,
+			},
+		}
+
+		batchWriter.fileSeq = f.fileSeq
+		batchWriter.entrySeq = f.entrySeq
+	}
+
+	// TODO plumb errors, context
+	return linearizeUpdates(memstore, previousPrices, batchWriter)
+}

--- a/storage/startup_test.go
+++ b/storage/startup_test.go
@@ -1,0 +1,94 @@
+package storage
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func init() {
+	FlushInterval = 10 * time.Millisecond
+}
+
+func TestSnapshotConsistency(t *testing.T) {
+	// stack of snapshots that should all agree with each other
+	m := modelStack{t, newMemFS(), nil}
+
+	checkModelConsistency := func() {
+		for _, productId := range []string{"foo", "bar", "baz", "qux", "zot", "wat", "lol"} {
+			if _, _, err := m.LastPrice(productId); err != nil {
+				t.Error(err)
+			}
+		}
+	}
+
+	_ = m.UpdatePrice("foo", "3.50")
+	checkModelConsistency()
+	m.checkpoint()
+	checkModelConsistency()
+	_ = m.UpdatePrice("bar", "2.20")
+	checkModelConsistency()
+	_ = m.UpdatePrice("bar", "2.21")
+	checkModelConsistency()
+	_ = m.UpdatePrice("zot", "1000")
+	checkModelConsistency()
+	_ = m.UpdatePrice("qux", "2.22")
+	checkModelConsistency()
+	time.Sleep(FlushInterval)
+	m.checkpoint()
+	checkModelConsistency()
+	_ = m.UpdatePrice("foo", "3.75")
+	checkModelConsistency()
+	_ = m.UpdatePrice("baz", "1.23")
+	checkModelConsistency()
+	m.checkpoint()
+	checkModelConsistency()
+	_ = m.UpdatePrice("wat", "0.01")
+	checkModelConsistency()
+	time.Sleep(FlushInterval)
+	checkModelConsistency()
+	_ = m.UpdatePrice("baz", "1.79")
+	checkModelConsistency()
+	m.checkpoint()
+	checkModelConsistency()
+
+	// TODO at least: 1 old, 1 new, 1 updated file per checkpoint, 3 snapshot layers deep
+}
+
+type modelStack struct {
+	testing.TB
+	fs
+	models []priceModel
+}
+
+func (s modelStack) checkpoint() {
+	time.Sleep(2 * FlushInterval) // allow all buffers to flush // FIXME really hacky
+	s.models = append(s.models, newFromFS(s.fs.(*memFS).clone()))
+}
+
+func (s *modelStack) UpdatePrice(productId string, price json.Number) (err error) {
+	if len(s.models) == 0 {
+		s.models = []priceModel{newFromFS(s.fs)}
+	}
+
+	for _, model := range s.models {
+		collectErrors(&err, model.UpdatePrice(productId, price))
+	}
+	return
+}
+
+func (s modelStack) LastPrice(productId string) (p json.Number, t time.Time, err error) {
+	for i, model := range s.models {
+		mp, mt, merr := model.LastPrice(productId)
+
+		if i == 0 {
+			p, t, err = mp, mt, merr
+		}
+
+		if p != mp || t != mt || err != merr {
+			s.Error("model inconsistency for", productId)
+		}
+	}
+
+	return
+}


### PR DESCRIPTION
This work started when studying Kubernetes rolling deployments, single instance stateful applications, and physical volumes.

This is a significant simplification of the previous iteration, which used temporary files written atomically and wrote buffers all at once, with the main goal to reduce the state machine complexity of the storage.

The format was designed with [NDJSON](https://ndjson.org) in mind (also without the indentation implied to be a requirement in the specification), which has some significant advantages (see #12):
- no file finalization is required, query endpoint can see results with no additional functionality (currently not implemented for JSON array based format, see #14)
- no parsing required to recover from partially written data (which is possible because no length constraints are specified on the inputs) - just ignore everything after last `\n`.

The only persistent state inconsistency that may arise due to a hard crash would be missing hard links from the `results_by_product` subdirectory, which can be quickly scanned at startup (not yet implemented, see #13), which is pretty decently [crash only](https://dslab.epfl.ch/pubs/crashonly.pdf)